### PR TITLE
Updated jsdom + acceptance

### DIFF
--- a/acceptance-setup/__tests__/acceptance.js
+++ b/acceptance-setup/__tests__/acceptance.js
@@ -1,6 +1,5 @@
 /**
  * @testEnvironment jsdom
- * @ jsdom
  */
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;

--- a/acceptance-setup/__tests__/acceptance.js
+++ b/acceptance-setup/__tests__/acceptance.js
@@ -1,3 +1,8 @@
+/**
+ * @testEnvironment jsdom
+ * @ jsdom
+ */
+
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
 
 const server = require("../server");
@@ -22,10 +27,8 @@ let registry;
 let testServer;
 
 const semverRegex = /\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z-]+(?:\.[\da-z-]+)*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?\b/gi;
-const consoleError = global.console.error;
 
 beforeAll(done => {
-  global.console.error = jest.fn();
   fs.removeSync(path.join(ocComponentPath, "_package"));
   cli.package(
     {
@@ -63,7 +66,6 @@ beforeAll(done => {
 });
 
 afterAll(done => {
-  global.console.error = consoleError;
   testServer.close(() => {
     registry.close(() => {
       fs.removeSync(path.join(ocComponentPath, "_package"));
@@ -93,8 +95,8 @@ test("Registry should correctly serve rendered and unrendered components", done 
     .catch(err => expect(err).toBeNull());
 
   Promise.all([rendered, unrendered])
-    .then(done)
-    .catch(done);
+    .then(() => done())
+    .catch(err => done(err));
 });
 
 test("server-side-side rendering", done => {
@@ -104,9 +106,7 @@ test("server-side-side rendering", done => {
       expect(domVersionless).toMatchSnapshot();
       done();
     })
-    .catch(err => {
-      expect(err).toBeNull();
-    });
+    .catch(err => done(err));
 });
 
 test("client-side-side rendering", done => {
@@ -126,7 +126,5 @@ test("client-side-side rendering", done => {
         done();
       }, 5000);
     })
-    .catch(err => {
-      expect(err).toBeNull();
-    });
+    .catch(err => done(err));
 });

--- a/acceptance-setup/package.json
+++ b/acceptance-setup/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.15",
   "devDependencies": {
     "fs-extra": "5.0.0",
-    "jsdom": "^11.3.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "devDependencies": {
     "codecov": "3.0.0",
     "husky": "^0.14.3",
-    "jest": "^20.0.4",
+    "jest": "^22.1.4",
+    "jest-environment-jsdom": "^22.1.4",
     "lerna": "^2.4.0",
     "lint-staged": "6.1.0",
     "oc": "0.42.19",
@@ -26,6 +27,7 @@
     ]
   },
   "jest": {
+    "testEnvironment": "node",
     "roots": [
       "packages",
       "acceptance-setup"


### PR DESCRIPTION
Closes #118 #120 

- [x] Updated to latest jest
- [x] Defaulting to included version of JSDOM with Jest
- [x] Setting environment node for all the test, except JSDOM to specific ones (bye default Jest use a JSDOM environment, so we might want to use node fore anything node related)

