### PR TITLE
[DX-394] Include server.js sourcemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ package-lock.json
 npm-debug.log
 node_modules
 coverage
+.vscode


### PR DESCRIPTION
Needed for vscode to attach the debugger.
It just works! 
We wrap the server in the high order closure, but still for debugging purposes, we are pretty much tackling just the origin server which is then sourcemapped by webpack as included with his own full path, so it attaches and I can properly debug it. Easier than I thought it could be :)