### PR TITLE
fix(oc-template-react-compiler): extract text ignore order

### DIFF
--- a/packages/oc-template-react-compiler/lib/to-abstract-base-template-utils/webpackConfigurator.js
+++ b/packages/oc-template-react-compiler/lib/to-abstract-base-template-utils/webpackConfigurator.js
@@ -45,7 +45,8 @@ module.exports = function webpackConfigGenerator(options) {
   let plugins = [
     new ExtractTextPlugin({
       filename: "[name].css",
-      allChunks: true
+      allChunks: true,
+      ignoreOrder: true
     }),
     new webpack.DefinePlugin({
       "process.env.NODE_ENV": JSON.stringify(


### PR DESCRIPTION
Ignore order on css extract text plugin