### PR TITLE
added babel preset react to server's webpack configuration

### DIFF
--- a/packages/oc-template-react-compiler/lib/to-abstract-base-template-utils/oc-webpack/lib/configurator/server/index.js
+++ b/packages/oc-template-react-compiler/lib/to-abstract-base-template-utils/oc-webpack/lib/configurator/server/index.js
@@ -31,6 +31,9 @@ module.exports = function webpackConfigGenerator(options) {
                 node: 6
               }
             }
+          ],
+          [
+            require.resolve("babel-preset-react")
           ]
         ],
         plugins: [


### PR DESCRIPTION
Added babel-preset-react in server's webpack configuration to allow server side rendering of styled-components. The idea is to collect the styles of a react component in the server.js and pass it as a props.