### PR TITLE
Security - Bumps lodash@^4.17.21 for critical security patch

### DIFF
--- a/packages/oc-template-react-compiler/package.json
+++ b/packages/oc-template-react-compiler/package.json
@@ -33,7 +33,7 @@
     "css-loader": "1.0.1",
     "fs-extra": "8.1.0",
     "infinite-loop-loader": "1.0.6",
-    "lodash": "4.17.19",
+    "lodash": "^4.17.21",
     "memory-fs": "0.4.1",
     "mini-css-extract-plugin": "0.8.0",
     "node-dir": "0.1.17",


### PR DESCRIPTION
Bumps `lodash@^4.17.21` to patch a critical security vulnerability in the current hoisted version `4.17.19`.

**NOTE:** Uses a minor semver to allow `lodash` to be easily bumped for future minor and patch versions. If this is preferred not to be used, I can revert this to a fixed version.

Resolves: #650 